### PR TITLE
Minor TYPO3 10.4 compatibility changes

### DIFF
--- a/Classes/Controller/MediaAlbumController.php
+++ b/Classes/Controller/MediaAlbumController.php
@@ -388,7 +388,11 @@ class MediaAlbumController extends ActionController
     protected function pageNotFound($message)
     {
         if (!empty($GLOBALS['TSFE'])) {
-            $GLOBALS['TSFE']->pageNotFoundAndExit($message);
+            $response = GeneralUtility::makeInstance(ErrorController::class)->pageNotFoundAction(
+                $GLOBALS['TYPO3_REQUEST'],
+                $message
+            );
+            throw new ImmediateResponseException($response, 1605182708235);
         } else {
             echo $message;
         }

--- a/Classes/Controller/MediaAlbumController.php
+++ b/Classes/Controller/MediaAlbumController.php
@@ -27,18 +27,23 @@ namespace MiniFranske\FsMediaGallery\Controller;
 
 use MiniFranske\FsMediaGallery\Domain\Model\MediaAlbum;
 use MiniFranske\FsMediaGallery\Utility\PageUtility;
+use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Frontend\Controller\ErrorController;
 
 /**
  * MediaAlbumController
  */
 class MediaAlbumController extends ActionController
 {
+    /**
+     * @var string Name of the extension this controller belongs to
+     */
+    protected $extensionName = 'fs_media_gallery';
 
     /**
      * mediaAlbumRepository


### PR DESCRIPTION
* Added property `extensionName` so `LocalizationUtility:translate` works
* Replaced deprecated and removed `pageNotFoundAndExit` with PSR-7 response
