### PR TITLE
[TASK] Do not show 404 page when album/asset not found

### DIFF
--- a/Classes/Controller/MediaAlbumController.php
+++ b/Classes/Controller/MediaAlbumController.php
@@ -293,11 +293,15 @@ class MediaAlbumController extends ActionController
      */
     public function showAlbumByConfigAction()
     {
-        // get all request arguments (e.g. pagination widget)
-        $arguments = $this->request->getArguments();
-        // set album id from settings
-        $arguments['mediaAlbum'] = $this->settings['mediaAlbum'];
-        $this->forward('showAlbum', null, null, $arguments);
+        $mediaAlbum = $this->mediaAlbumRepository->findByUid((int)$this->settings['mediaAlbum'], false);
+        if ($mediaAlbum) {
+            // get all request arguments (e.g. pagination widget)
+            $arguments = $this->request->getArguments();
+            // set album id from settings
+            $arguments['mediaAlbum'] = $this->settings['mediaAlbum'];
+
+            $this->forward('showAlbum', null, null, $arguments);
+        }
     }
 
     /**

--- a/Resources/Private/Templates/MediaAlbum/ShowAlbumByConfig.html
+++ b/Resources/Private/Templates/MediaAlbum/ShowAlbumByConfig.html
@@ -1,0 +1,11 @@
+<div xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	 xmlns:f="http://typo3.org/ns/fluid/ViewHelpers"
+	 xmlns:mf="http://typo3.org/ns/MiniFranske/FsMediaGallery/ViewHelpers">
+
+	<f:layout name="Default" />
+
+	<f:section name="main">
+		<p><f:translate key="no_album_found" /></p>
+	</f:section>
+
+</div>


### PR DESCRIPTION
When the plugin is configured to show a selected media album (URL handover disabled), it should not show the 404
page when the album could not be found. Instead, an error is rendered by the given Fluid view.