### PR TITLE
[BUGFIX] Drop the vendor-less replace entry

Composer rejects a replace entry without a vendor prefix:

    replace.fs_media_gallery is invalid, it should have a vendor name, a
    forward slash, and a package name

which makes every composer operation on this package fail outright, not
only SBOM generation. The vendor-qualified equivalent,
typo3-ter/fs-media-gallery, is already declared alongside it, so the
bare key is redundant as well as invalid.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     }
   },
   "replace": {
-    "fs_media_gallery": "self.version",
     "typo3-ter/fs-media-gallery": "self.version"
   },
   "extra": {


### PR DESCRIPTION
[BUGFIX] Drop the vendor-less replace entry

Composer rejects a replace entry without a vendor prefix:

    replace.fs_media_gallery is invalid, it should have a vendor name, a
    forward slash, and a package name

which makes every composer operation on this package fail outright, not
only SBOM generation. The vendor-qualified equivalent,
typo3-ter/fs-media-gallery, is already declared alongside it, so the
bare key is redundant as well as invalid.