### PR TITLE
[BUGFIX] Correct the supported versions table

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,16 +8,16 @@ timely manner, and to coordinating responsibly with security researchers.
 
 ## Supported Versions
 
-This product has not had a tagged release yet; the table below describes the development state of the default branch.
-
 Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
-| 1.x            | :x:                 |
-| < 1.0          | :x:                 |
+| 2.x            | :x:                 |
+| < 2.0          | :x:                 |
+
+This product has not had a tagged release yet; the line listed above describes the development state of the default branch.
 
 > **Note:** the newest version of this product targets a TYPO3 version that has left
 > regular LTS maintenance, so no version is currently covered by security updates.


### PR DESCRIPTION
Corrects the supported-versions table.

The previous version read the TYPO3 range from the **default branch** and attributed
it to the newest **released** major. Those are different things wherever development
has moved ahead of the last release, and the result overstated what the released line
supports.

The table now distinguishes three lines — the development line on the default branch
(listed only when it is genuinely ahead of the newest release), the newest released
major, and the one before it — each judged against the TYPO3 versions that line
actually declares. A line counts as supported while the newest TYPO3 version it
supports is still under **regular** LTS maintenance per get.typo3.org: TYPO3 13 (until
2027-12-31) and 14 (until 2029-06-30) qualify; 12 and below are ELTS or end of life.

The support-end date is the LTS end of the newest TYPO3 version across the supported
lines.
